### PR TITLE
Replacing trustnobank.eth with trustsnobank.eth

### DIFF
--- a/app/js/domains.json
+++ b/app/js/domains.json
@@ -11,7 +11,7 @@
   {"name": "etherbase", "version": "1.0"},
   {"name": "gimmethe", "version": "1.0"},
   {"name": "thecryptoguy", "version": "1.0"},
-  {"name": "trustnobank", "version": "1.0"},
+  {"name": "trustsnobank", "version": "1.0"},
   {"name": "wantsome", "version": "1.0"},
   {"name": "xannyfamily", "version": "1.0"}
 ]


### PR DESCRIPTION
As noted in my comments from the previous PR, trustnobank.eth had existing subdomains before transferring to the smart contract which seems to cause conflicts and result in it not showing up at all, so I swallowed by pride (and fiver) and registered trustsnobank.eth instead and transferred it direct to the contract with no subdomains already attached, this should now work as normal.